### PR TITLE
Multiple quality improvements - squid:S1213, squid:SwitchLastCaseIsDe…

### DIFF
--- a/app/src/main/java/com/cooltechworks/scratchview/demo/FlipAnimator.java
+++ b/app/src/main/java/com/cooltechworks/scratchview/demo/FlipAnimator.java
@@ -47,12 +47,12 @@ public class FlipAnimator extends Animation {
     /**
      * Center X - holds the center X point of the parent view where the animation should take place.
      */
-    private float centerX;
+    private final float centerX;
 
     /**
      * Center Y - holds the center Y point of the parent view where the animation should take place.
      */
-    private float centerY;
+    private final float centerY;
 
     /**
      * Flag to represent whether to flip originate from fromView to toView or vice versa
@@ -63,22 +63,6 @@ public class FlipAnimator extends Animation {
     private boolean visibilitySwapped;
 
     private int rotationDirection = DIRECTION_X;
-
-    public int getRotationDirection() {
-        return rotationDirection;
-    }
-
-    public void setRotationDirection(int rotationDirection) {
-        this.rotationDirection = rotationDirection;
-    }
-
-    public int getTranslateDirection() {
-        return translateDirection;
-    }
-
-    public void setTranslateDirection(int translateDirection) {
-        this.translateDirection = translateDirection;
-    }
 
     private int translateDirection = DIRECTION_Z;
 
@@ -102,6 +86,22 @@ public class FlipAnimator extends Animation {
         setDuration(500);
         setFillAfter(true);
         setInterpolator(new AccelerateDecelerateInterpolator());
+    }
+
+    public int getRotationDirection() {
+        return rotationDirection;
+    }
+
+    public void setRotationDirection(int rotationDirection) {
+        this.rotationDirection = rotationDirection;
+    }
+
+    public int getTranslateDirection() {
+        return translateDirection;
+    }
+
+    public void setTranslateDirection(int translateDirection) {
+        this.translateDirection = translateDirection;
     }
 
     public void reverse() {

--- a/views/src/main/java/com/cooltechworks/views/ScratchImageView.java
+++ b/views/src/main/java/com/cooltechworks/views/ScratchImageView.java
@@ -112,14 +112,6 @@ public class ScratchImageView extends ImageView {
 
     }
 
-    /**
-     * Set the strokes width based on the parameter multiplier.
-     * @param multiplier can be 1,2,3 and so on to set the stroke width of the paint.
-     */
-    public void setStrokeWidth(int multiplier) {
-        mErasePaint.setStrokeWidth(multiplier * STROKE_WIDTH);
-    }
-
     public ScratchImageView(Context context, AttributeSet set) {
         super(context, set);
         init();
@@ -128,6 +120,14 @@ public class ScratchImageView extends ImageView {
     public ScratchImageView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         init();
+    }
+
+    /**
+     * Set the strokes width based on the parameter multiplier.
+     * @param multiplier can be 1,2,3 and so on to set the stroke width of the paint.
+     */
+    public void setStrokeWidth(int multiplier) {
+        mErasePaint.setStrokeWidth(multiplier * STROKE_WIDTH);
     }
 
     /**
@@ -200,7 +200,7 @@ public class ScratchImageView extends ImageView {
      */
     public void clear() {
 
-        int bounds[] = getImageBounds();
+        int[] bounds = getImageBounds();
         int left = bounds[0];
         int top = bounds[1];
         int right = bounds[2];
@@ -282,6 +282,8 @@ public class ScratchImageView extends ImageView {
             case MotionEvent.ACTION_UP:
                 touch_up();
                 invalidate();
+                break;
+            default:
                 break;
         }
         return true;

--- a/views/src/main/java/com/cooltechworks/views/ScratchTextView.java
+++ b/views/src/main/java/com/cooltechworks/views/ScratchTextView.java
@@ -104,14 +104,6 @@ public class ScratchTextView extends TextView {
 
     }
 
-    /**
-     * Set the strokes width based on the parameter multiplier.
-     * @param multiplier can be 1,2,3 and so on to set the stroke width of the paint.
-     */
-    public void setStrokeWidth(int multiplier) {
-        mErasePaint.setStrokeWidth(multiplier * STROKE_WIDTH);
-    }
-
     public ScratchTextView(Context context, AttributeSet set) {
         super(context, set);
         init();
@@ -120,6 +112,14 @@ public class ScratchTextView extends TextView {
     public ScratchTextView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         init();
+    }
+
+    /**
+     * Set the strokes width based on the parameter multiplier.
+     * @param multiplier can be 1,2,3 and so on to set the stroke width of the paint.
+     */
+    public void setStrokeWidth(int multiplier) {
+        mErasePaint.setStrokeWidth(multiplier * STROKE_WIDTH);
     }
 
     /**
@@ -224,7 +224,7 @@ public class ScratchTextView extends TextView {
      */
     public void reveal() {
 
-        int bounds[] = getTextBounds(1.5f);
+        int[] bounds = getTextBounds(1.5f);
         int left = bounds[0];
         int top = bounds[1];
         int right = bounds[2];
@@ -273,6 +273,8 @@ public class ScratchTextView extends TextView {
             case MotionEvent.ACTION_UP:
                 drawPath();
                 invalidate();
+                break;
+            default:
                 break;
         }
         return true;
@@ -369,7 +371,7 @@ public class ScratchTextView extends TextView {
 
         String text = getText().toString();
 
-        int dimens[] = getTextDimens(text, paint);
+        int[] dimens = getTextDimens(text, paint);
         int width = dimens[0];
         int height = dimens[1];
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause
squid:S1197 - Array designators "[]" should be on the type, not the variable
pmd:ImmutableField - Immutable Field

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213
https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1197
https://dev.eclipse.org/sonar/coding_rules#q=pmd:ImmutableField

Please let me know if you have any questions.

M-Ezzat